### PR TITLE
Add sub_name and sub_number to /api/v1/accounts

### DIFF
--- a/accounts_index.md
+++ b/accounts_index.md
@@ -51,6 +51,16 @@ limit  <br> *optional*  | 1ページあたりのエレメント数
             "service_id": 1,
             "status": 2,
             "hashed_id": "LlPqfqeeCZavwPBLmUy6xg==",
+            "sub_accounts" : [
+              {
+                "sub_name" : null,
+                "sub_number" : null
+              },
+              {
+                "sub_name" : "本店",
+                "sub_number" : "0999999",
+              }
+            ],
             "service": {
               "category_name": "銀行",
               "category_type": "BANK",

--- a/accounts_index.md
+++ b/accounts_index.md
@@ -15,6 +15,8 @@ memo | ユーザーが設定した登録金融機関に関するメモ
 msg_flag | true: messageを表示する false(default): message非表示
 message | ユーザーに通知する必要があるメッセージ
 status | アグリゲーションの状態を表す 0:正常（取得済み）、1:取得中、2:取得エラー、3:取得停止中
+sub_accounts[:sub_name] | 支店名
+sub_accounts[:sub_number] | 口座番号
 
 ## Parameters
 name | Description 

--- a/accounts_show.md
+++ b/accounts_show.md
@@ -53,6 +53,16 @@ id  <br> *required* | 登録金融機関ID *hashed*
         "service_id": 7,
         "status": 2,
         "hashed_id": "84dG3OLcZt_gLm66DESKzw==",
+        "sub_accounts" : [
+          {
+            "sub_name" : null,
+            "sub_number" : null
+          },
+          {
+            "sub_name" : "本店",
+            "sub_number" : "0999999",
+          }
+        ],
         "service": {
           "category_name": "銀行",
           "category_type": "BANK",

--- a/accounts_show.md
+++ b/accounts_show.md
@@ -16,6 +16,8 @@ memo | ユーザーが設定した登録金融機関に関するメモ
 msg_flag | true: messageを表示する false(default): message非表示
 message | ユーザーに通知する必要があるメッセージ
 status | アグリゲーションの状態を表す 0:正常（取得済み）、1:取得中、2:取得エラー、3:取得停止中
+sub_accounts[:sub_name] | 支店名
+sub_accounts[:sub_number] | 口座番号
 exclusive_service_forms | 金融機関登録に必要なフォーム情報のリスト
 exclusive_service_form[encrypt_flag] | 暗号化対象項目
 exclusive_service_form[format] | 入力値の制約を正規表現チェック。ブランクは正規表現によるチェックなし。input_typeが'radio' の場合は、radioボタンの選択項目リスト


### PR DESCRIPTION
`/api/v1/accounts` と `/api/v1/accounts/:id` のレスポンスに支店名と口座番号が追加
https://github.com/moneyforward/pfm_web/pull/3066