### PR TITLE
Fix link, description

### DIFF
--- a/api-referrence.md
+++ b/api-referrence.md
@@ -125,8 +125,8 @@ OAuth2: Authorization Code Flow
 |--------------------------------------|-------|-------------------------------------|----------------|
 |[種類の一覧の取得](transactions_index.md)|GET 　  |/api/v1/transactions/categories      |`transactions`  |
 |[一覧の取得](transactions_index.md)     |GET 　  |/api/v1/transactions                 |`transactions`  |
-|[合計の取得](transactions_index.md)     |GET 　  |/api/v1/derived/transaction_summaries|`transactions`  |
-|[履歴の取得](transactions_index.md)     |GET    |/api/v1/derived/transaction_histories|`transactions`  |
+|[合計の取得](transaction_summaries_index.md)     |GET 　  |/api/v1/derived/transaction_summaries|`transactions`  |
+|[履歴の取得](transaction_histories_index.md)     |GET    |/api/v1/derived/transaction_histories|`transactions`  |
 
 ## 連絡先
 

--- a/transaction_histories_index.md
+++ b/transaction_histories_index.md
@@ -1,18 +1,17 @@
-# GET /api/v1/derived/transaction_summaries
+# GET /api/v1/derived/transaction_histories
 
-指定された期間まで遡り現在からその期間までの収支履歴を取得します。
-週 or 月単位で取得できます。
+指定された過去から現在までの期間の収支履歴を取得します。期間は週または月の倍数で指定します。
 
 ## Resource URL
 
-https://moneyforward.com/api/v1/derived/transaction_summaries
+https://moneyforward.com/api/v1/derived/transaction_histories
 
 ## Parameters
 
 Name | Description
 ----- | -----
-past <br> *optional* | 遡りたい過去 <br> ※ デフォルト: `0`
-period <br> *optional* | `week` or `month` <br> ※ デフォルト: `month`
+period <br> *optional* | 期間を指定する単位。`week` または `month` 。デフォルト: `month`。
+past <br> *optional* | 上記単位で計った期間の長さ。 デフォルト: `0`。
 
 ## Example
 

--- a/transaction_summaries_index.md
+++ b/transaction_summaries_index.md
@@ -1,7 +1,6 @@
 # GET /api/v1/derived/transaction_summaries
 
-**ある特定期間** でのカテゴリ毎の収支を取得します。
-週 or 月単位で取得できます。
+指定された過去から現在までの期間のカテゴリ毎の収支を取得します。期間は週または月の倍数で指定します。
 
 ## Resource URL
 
@@ -11,8 +10,8 @@ https://moneyforward.com/api/v1/derived/transaction_summaries
 
 Name | Description
 ----- | -----
-past <br> *optional* | 遡りたい過去 <br> ※ デフォルト: `0`
-period <br> *optional* | `week` or `month` <br> ※ デフォルト: `month`
+period <br> *optional* | 期間を指定する単位。`week` または `month` 。デフォルト: `month`。
+past <br> *optional* | 上記単位で計った期間の長さ。 デフォルト: `0`。
 
 ## Example
 


### PR DESCRIPTION
* api-referrence.md からのリンクが間違っていた。直した。
* transaction_histories_index.md の上部のURLが、 transaction_summaries_index.md 用のものになっていた。直した。
* transaction_histories_index.md と transaction_summaries_index.md 用の説明を改良した。