### PR TITLE
Revert sso_tokens

### DIFF
--- a/api-referrence.md
+++ b/api-referrence.md
@@ -130,13 +130,6 @@ OAuth2: Authorization Code Flow
 |[合計の取得](transaction_summaries_index.md)     |GET 　  |/api/v1/derived/transaction_summaries|`transactions`  |
 |[履歴の取得](transaction_histories_index.md)     |GET    |/api/v1/derived/transaction_histories|`transactions`  |
 
-### SSOトークン
-
-|                           |メソッド |URI               |必要な権限(スコープ)   |
-|---------------------------|------|------------------|--------------------|
-|[取得](sso_tokens_create.md)|POST  |/api/v1/sso_tokens|`manage_sso`|
-
-
 ## 連絡先
 
 ご不明点、ご要望等は以下までご連絡ください。

--- a/api-referrence.md
+++ b/api-referrence.md
@@ -130,6 +130,13 @@ OAuth2: Authorization Code Flow
 |[合計の取得](transaction_summaries_index.md)     |GET 　  |/api/v1/derived/transaction_summaries|`transactions`  |
 |[履歴の取得](transaction_histories_index.md)     |GET    |/api/v1/derived/transaction_histories|`transactions`  |
 
+### SSOトークン
+
+|                           |メソッド |URI               |必要な権限(スコープ)   |
+|---------------------------|------|------------------|--------------------|
+|[取得](sso_tokens_create.md)|POST  |/api/v1/sso_tokens|`manage_sso`|
+
+
 ## 連絡先
 
 ご不明点、ご要望等は以下までご連絡ください。

--- a/sso_tokens_create.md
+++ b/sso_tokens_create.md
@@ -1,0 +1,33 @@
+# POST /api/v1/sso_tokens
+
+SSOトークン取得
+
+## Resrouce URL
+https://moneyforward.com/api/v1/sso_tokens
+
+## Parameters
+name | Description
+-----|-----
+sso_tokens[redirect_path] | リダイレクト先URI(default=/)
+
+## Example
+
+### request
+
+> **POST** https://moneyforward.com/api/v1/sso_tokens
+
+### request-body
+
+    {
+      "sso_token": {
+        "redirect_path": "/accounts"
+      }
+    }
+
+### response
+
+    {
+      "sso_token" {
+        "token": トークン文字列
+      }
+    }


### PR DESCRIPTION
* /api/v1/sso_tokens はもう外部には新たに開放しないという考えで、https://github.com/moneyforward/api-doc/pull/11 によりドキュメントが削除されたが、 `sso` という権限が与えられ、結局使うことになった。
* そのことに加えて、pfm_web/doc/api/v1 にもAPIのドキュメントがあり、本リポジトリと重複しているので、pfm_web/doc/api/v1 にあるものは本リポジトリに持ってきて、pfm_web/doc/api/v1 を削除したい。
* `sso_tokens` 以外のAPIでは、 `create` にあたるものには `manage_` という接頭辞を権限に付けているので、それに従って `sso_tokens` も `sso` を廃止して、 `manage_sso` という権限に変更する。これについては@kanebako 了承済み。Cf. https://github.com/moneyforward/pfm_web/pull/4152, https://mf.esa.io/posts/28710