### PR TITLE
コンマをセミコロンにする

### DIFF
--- a/accounts_index.md
+++ b/accounts_index.md
@@ -36,7 +36,7 @@ X-MFOAuthToken: "Bearer 0d171c8d5e6b023fa13ebd2209453f95e566ba4cb16a1bd1c3becdf0
 | `accounts[i][account][memo]` | ユーザーが設定したメモ |
 | `accounts[i][account][message]` | 金融機関からユーザーへの通知 |
 | `accounts[i][account][msg_flag]` | `true`: `message` を表示する, `false` (デフォルト): `message` を表示しない |
-| `accounts[i][account][status]` | 金融機関からの情報の取得状況, `0`: 取得済み, `1`: 取得中、`2`: 取得エラー, `3`: 取得停止中 |
+| `accounts[i][account][status]` | 金融機関からの情報の取得状況; `0`: 取得済み, `1`: 取得中、`2`: 取得エラー, `3`: 取得停止中 |
 | `accounts[i][account][sub_accounts][j][sub_name]` | 金融機関の支店名 |
 | `accounts[i][account][sub_accounts][j][sub_number]` | 口座番号 |
  


### PR DESCRIPTION
* いつでも

* 表のセルの中の値の説明で、文に相当するものが複数有るときにはセミコロンで区切ることにしているが、間違ってコンマを使っていた。これを直した。