### PR TITLE
コメントアウト行を表示する

### DIFF
--- a/api-referrence.md
+++ b/api-referrence.md
@@ -78,7 +78,7 @@ API の使用時には、始めに認可を得、アクセストークンを得�
 |[ユーザーの情報を得る](user_show.md)               |GET            |/api/v1/user       |なし                          |
 |[ユーザーのSSOトークンを登録する](sso_tokens_create.md)|POST           |/api/v1/sso_tokens|`sso_tokens`                  |
 |[ユーザーのデモグラフィック情報を閲覧する](profile_show.md)|GET           |/api/v1/profile|`profile`                  |
-[//]: # |ユーザーの情報を削除する|DELETE|/api/v1/user||
+|ユーザーの登録を削除する                           |DELETE         |/api/v1/user       |非公開                        |
 
 ### 金融機関情報の取得
 


### PR DESCRIPTION
* いつでも
* コメントアウトした行がうまく隠されていなかった。
* よく考えたら、コメントアウト行として残しておくのはメンテナンス上良くないので、コメントアウトをやめ、普通に表示し、非公開と書く。