### PR TITLE
Fix descriptions on 'period' and 'past' parameters

### DIFF
--- a/transaction_histories_index.md
+++ b/transaction_histories_index.md
@@ -13,8 +13,8 @@ GET https://moneyforward.com/api/v1/derived/transaction_histories
 | 場所 | 随意性 | 名称 | 内容 |
 | ---- | ---- | ---- | --- |
 | ヘッダー | 必須 | `Authorization` または `X-MFOAuthToken` | ```Bearer `アクセストークン` ```; ここで `アクセストークン` は [`access_token`](token.md) の値 |
-| クエリー | 任意; デフォルト: `month` | `period` | 期間を指定する単位; `week`: 日曜始まりの週, `month`: 月 |
-| クエリー | 任意; デフォルト: `0` | `past` | 上記単位で計った期間の長さ |
+| クエリー | 任意; デフォルト: `month` | `period` | 期間の単位; `week`: 日曜始まりの週, `month`: 月 |
+| クエリー | 任意; デフォルト: `0` | `past` | 情報を得る期間の長さ; 上記単位で計る; [`GET https://moneyforward.com/api/v1/derived/transaction_summaries`](transaction_summaries_index.md) の場合と意味が異なる |
 
 ### 例
 

--- a/transaction_summaries_index.md
+++ b/transaction_summaries_index.md
@@ -13,8 +13,8 @@ GET https://moneyforward.com/api/v1/derived/transaction_summaries
 | 場所 | 随意性 | 名称 | 内容 |
 | ---- | ---- | ---- | --- |
 | ヘッダー | 必須 | `Authorization` または `X-MFOAuthToken` | ```Bearer `アクセストークン` ```; ここで `アクセストークン` は [`access_token`](token.md) の値 |
-| クエリー | 任意; デフォルト: `month` | `period` | 期間を指定する単位; `week`: 日曜始まりの週, `month`: 月 |
-| クエリー | 任意; デフォルト: `0` | `past` | 上記単位で計った期間の長さ |
+| クエリー | 任意; デフォルト: `month` | `period` | 期間の単位; `week`: 日曜始まりの週, `month`: 月 |
+| クエリー | 任意; デフォルト: `0` | `past` | 情報を得る期間がどれだけ過去か; 上記単位で計る; [`GET https://moneyforward.com/api/v1/derived/transaction_histories`](transaction_histories_index.md) の場合と意味が異なる |
 | クエリー | 任意; デフォルト: `large` | `category_size` | 集計する分類の大きさ; `large`: 大項目, `middle`: 中項目 |
 
 ### 例


### PR DESCRIPTION
* なるはや
* transaction_summaries_index での `past` パラメーターの意味が間違っていた。直した。